### PR TITLE
docs: add TODO placeholder for hero-loop GIF in README (Closes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ https://github.com/user-attachments/assets/b561ca91-f033-4961-ac0e-862655caad9f
 
 https://github.com/user-attachments/assets/b7666b02-cfbc-4774-80d2-f70bbe26bbae
 
+<!--
+  TODO: 核心 loop GIF（欢迎贡献录屏）
+  ----------
+  在首屏添加一段 3–4 秒的可循环演示 GIF，让访客一眼就能理解隐界的产品形态。
+
+  建议画面（任选其一）：
+  - AI 主动发一条朋友圈 → 另一个 AI 在底下评论 → 推到你这
+  - 群聊里 AI 之间互相抬杠、替你说话
+  - "自己" 🪞 在深夜陪你聊天
+  - 摇一摇遇见一位新角色，自动生成好友申请文案
+
+  最终文件放在 docs/assets/hero-loop.gif
+  分辨率建议 1000px 宽内，文件大小 ≤ 5MB（GitHub 渲染会截断大文件）
+  不要出现鼠标指针、多余 UI chrome、真实个人信息
+
+  录好之后直接提 PR 替换掉这段注释即可。
+  推荐工具：ScreenToGif（Windows）/ Kap（macOS）+ ezgif.com 压缩
+-->
+![隐界核心演示](docs/assets/hero-loop.gif)
+
 ## ✨ 这是什么
 
 市面上的 AI 产品大致停留在两种形态：


### PR DESCRIPTION
## 改动

在 README 首屏添加了一段 HTML 注释占位符，**邀请贡献者录制核心 loop GIF**。

### 放置位置
两个嵌入视频下方、"✨ 这是什么"章节之上。

### 占位符内容
```html
<!--
  TODO: 核心 loop GIF（欢迎贡献录屏）
  ...
-->
```

### GIF 要求（摘自 #19）
- 最终文件：`docs/assets/hero-loop.gif`
- 分辨率 ≤ 1000px 宽，文件大小 ≤ 5MB
- 3–4 秒可循环、无需声音
- 推荐画面：AI 朋友圈互动 / 群聊抬杠 / 🪞 深夜聊天 / 摇一摇
- 无鼠标指针、无多余 UI chrome、无真实个人信息

Closes #19