### PR TITLE
chore(cloud-console/i18n): 删 PR4 后悬空的 2 个 formatter

### DIFF
--- a/apps/app/src/components/chat-composer.tsx
+++ b/apps/app/src/components/chat-composer.tsx
@@ -2999,7 +2999,7 @@ export function ChatComposer({
           ref={isDesktop ? desktopStickerRef : undefined}
           className={`relative ${
             isDesktop
-              ? "overflow-hidden rounded-[16px] border border-black/8 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.06)]"
+              ? "rounded-[16px] border border-black/8 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.06)]"
               : "space-y-1.5"
           }`}
         >
@@ -3063,7 +3063,7 @@ export function ChatComposer({
                 />
               </div>
 
-              <div className="flex items-center justify-between gap-3 border-t border-black/6 bg-[#fafafa] px-3.5 py-2.5">
+              <div className="flex items-center justify-between gap-3 rounded-b-[16px] border-t border-black/6 bg-[#fafafa] px-3.5 py-2.5">
                 <div className="flex min-w-0 flex-1 items-center gap-2">
                   <DesktopToolbarGroup>
                     <DesktopToolbarButton

--- a/apps/app/src/components/chat-composer.tsx
+++ b/apps/app/src/components/chat-composer.tsx
@@ -2823,7 +2823,7 @@ export function ChatComposer({
       <div
         className={
           isDesktop
-            ? "relative border-t border-black/6 bg-[#ededed] px-3.5 py-3"
+            ? "relative isolate z-30 border-t border-black/6 bg-[#ededed] px-3.5 py-3"
             : "border-t border-black/6 bg-[#f7f7f7] px-2 pb-2 pt-1"
         }
         style={{
@@ -3087,7 +3087,7 @@ export function ChatComposer({
                         />
                         {desktopPlusMenuOpen &&
                         desktopPlusMenuView === "favorites" ? (
-                          <div className="absolute bottom-[calc(100%+0.55rem)] left-0 z-30 w-80 overflow-hidden rounded-[12px] border border-black/8 bg-white shadow-[0_12px_28px_rgba(15,23,42,0.14)]">
+                          <div className="absolute bottom-[calc(100%+0.55rem)] left-0 z-50 w-80 overflow-hidden rounded-[12px] border border-black/8 bg-white shadow-[0_12px_28px_rgba(15,23,42,0.14)]">
                             <DesktopFavoritePicker
                               favorites={desktopFavoriteRecords}
                               busy={composerPending}

--- a/apps/app/src/components/chat-message-list.tsx
+++ b/apps/app/src/components/chat-message-list.tsx
@@ -5979,6 +5979,7 @@ function ImageViewerOverlay({
   onOpenInWindow?: () => void;
   onPrint?: () => void;
 }) {
+  const t = useRuntimeTranslator();
   const isDesktop = variant === "desktop";
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const touchDeltaXRef = useRef(0);
@@ -6023,7 +6024,7 @@ function ImageViewerOverlay({
         type="button"
         onClick={onClose}
         className="absolute inset-0 cursor-default"
-        aria-label="关闭图片查看器"
+        aria-label={t(msg`关闭图片查看器`)}
       />
 
       {isDesktop ? (
@@ -6039,22 +6040,22 @@ function ImageViewerOverlay({
             </div>
             <div className="flex items-center gap-2">
               {onOpenInWindow ? (
-                <ViewerActionButton label="新窗口打开" onClick={onOpenInWindow}>
+                <ViewerActionButton label={t(msg`新窗口打开`)} onClick={onOpenInWindow}>
                   <ExternalLink size={16} />
                 </ViewerActionButton>
               ) : null}
               {onPrint ? (
-                <ViewerActionButton label="打印图片" onClick={onPrint}>
+                <ViewerActionButton label={t(msg`打印图片`)} onClick={onPrint}>
                   <Printer size={16} />
                 </ViewerActionButton>
               ) : null}
-              <ViewerActionButton label="保存图片" onClick={onSave}>
+              <ViewerActionButton label={t(msg`保存图片`)} onClick={onSave}>
                 <Download size={16} />
               </ViewerActionButton>
-              <ViewerActionButton label="定位到聊天位置" onClick={onLocate}>
+              <ViewerActionButton label={t(msg`定位到聊天位置`)} onClick={onLocate}>
                 <LocateFixed size={16} />
               </ViewerActionButton>
-              <ViewerActionButton label="关闭图片查看器" onClick={onClose}>
+              <ViewerActionButton label={t(msg`关闭图片查看器`)} onClick={onClose}>
                 <X size={16} />
               </ViewerActionButton>
             </div>
@@ -6063,14 +6064,14 @@ function ImageViewerOverlay({
           {onPrevious ? (
             <ViewerNavButton
               side="left"
-              label="上一张图片"
+              label={t(msg`上一张图片`)}
               onClick={onPrevious}
             >
               <ChevronLeft size={22} />
             </ViewerNavButton>
           ) : null}
           {onNext ? (
-            <ViewerNavButton side="right" label="下一张图片" onClick={onNext}>
+            <ViewerNavButton side="right" label={t(msg`下一张图片`)} onClick={onNext}>
               <ChevronRight size={22} />
             </ViewerNavButton>
           ) : null}
@@ -6080,7 +6081,7 @@ function ImageViewerOverlay({
           <div className="absolute inset-x-0 top-[calc(env(safe-area-inset-top,0px)+0.5rem)] z-10 flex items-start justify-between gap-3 px-3 text-white">
             <ViewerActionButton
               compact
-              label="关闭图片查看器"
+              label={t(msg`关闭图片查看器`)}
               onClick={onClose}
             >
               <X size={16} />
@@ -6093,14 +6094,14 @@ function ImageViewerOverlay({
                 {activeIndex + 1} / {total}
               </div>
             </div>
-            <ViewerActionButton compact label="保存图片" onClick={onSave}>
+            <ViewerActionButton compact label={t(msg`保存图片`)} onClick={onSave}>
               <Download size={16} />
             </ViewerActionButton>
           </div>
 
           {total > 1 ? (
             <div className="absolute inset-x-0 bottom-[calc(env(safe-area-inset-bottom,0px)+5.5rem)] z-10 px-6 text-center text-xs text-white/70">
-              左右滑动切换图片
+              {t(msg`左右滑动切换图片`)}
             </div>
           ) : null}
 
@@ -6108,7 +6109,7 @@ function ImageViewerOverlay({
             <div className="flex items-center justify-center gap-3">
               <ViewerActionButton
                 compact
-                label="定位到聊天位置"
+                label={t(msg`定位到聊天位置`)}
                 onClick={onLocate}
               >
                 <LocateFixed size={16} />
@@ -6116,14 +6117,14 @@ function ImageViewerOverlay({
               {onPrevious ? (
                 <ViewerActionButton
                   compact
-                  label="上一张图片"
+                  label={t(msg`上一张图片`)}
                   onClick={onPrevious}
                 >
                   <ChevronLeft size={18} />
                 </ViewerActionButton>
               ) : null}
               {onNext ? (
-                <ViewerActionButton compact label="下一张图片" onClick={onNext}>
+                <ViewerActionButton compact label={t(msg`下一张图片`)} onClick={onNext}>
                   <ChevronRight size={18} />
                 </ViewerActionButton>
               ) : null}
@@ -6167,6 +6168,7 @@ function LocationViewerOverlay({
   onLocate: () => void;
   onShareOrCopy: () => void;
 }) {
+  const t = useRuntimeTranslator();
   const isDesktop = variant === "desktop";
   const nativeMobileShareSupported = !isDesktop && isNativeMobileShareSurface();
 
@@ -6176,20 +6178,20 @@ function LocationViewerOverlay({
         type="button"
         onClick={onClose}
         className="absolute inset-0 cursor-default"
-        aria-label="关闭位置查看器"
+        aria-label={t(msg`关闭位置查看器`)}
       />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(74,222,128,0.22),transparent_34%),linear-gradient(180deg,rgba(15,23,42,0.12),rgba(15,23,42,0.72))]" />
       <div className="relative flex h-full flex-col">
         <div className="flex items-center justify-between px-4 pb-3 pt-[max(env(safe-area-inset-top,0px),1rem)] text-white">
           <div>
             <div className="text-[12px] uppercase tracking-[0.18em] text-white/60">
-              聊天位置
+              {t(msg`聊天位置`)}
             </div>
             <div className="mt-1 text-[18px] font-medium">
               {attachment.title}
             </div>
           </div>
-          <ViewerActionButton compact label="关闭位置查看器" onClick={onClose}>
+          <ViewerActionButton compact label={t(msg`关闭位置查看器`)} onClick={onClose}>
             <X size={18} />
           </ViewerActionButton>
         </div>
@@ -6207,7 +6209,7 @@ function LocationViewerOverlay({
 
             <div className="relative flex h-full flex-col justify-between p-5">
               <div className="self-start rounded-full border border-white/12 bg-white/10 px-3 py-1 text-[11px] tracking-[0.12em] text-white/72">
-                来自聊天中的位置卡片
+                {t(msg`来自聊天中的位置卡片`)}
               </div>
 
               <div className="flex flex-1 items-center justify-center">
@@ -6228,7 +6230,7 @@ function LocationViewerOverlay({
                     </div>
                     <div className="mt-1 text-[13px] leading-6 text-white/72">
                       {attachment.subtitle?.trim() ||
-                        "这条位置消息来自当前聊天场景，可继续回到消息定位。"}
+                        t(msg`这条位置消息来自当前聊天场景，可继续回到消息定位。`)}
                     </div>
                   </div>
                 </div>
@@ -6239,7 +6241,7 @@ function LocationViewerOverlay({
 
         <div className="flex flex-wrap items-center justify-center gap-3 px-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)] pt-2">
           <ViewerActionButton
-            label={nativeMobileShareSupported ? "系统分享" : "复制位置"}
+            label={nativeMobileShareSupported ? t(msg`系统分享`) : t(msg`复制位置`)}
             onClick={onShareOrCopy}
           >
             {nativeMobileShareSupported ? (
@@ -6248,7 +6250,7 @@ function LocationViewerOverlay({
               <Copy size={16} />
             )}
           </ViewerActionButton>
-          <ViewerActionButton label="定位消息" onClick={onLocate}>
+          <ViewerActionButton label={t(msg`定位消息`)} onClick={onLocate}>
             <LocateFixed size={16} />
           </ViewerActionButton>
         </div>
@@ -6270,6 +6272,7 @@ function NoteViewerOverlay({
   onLocate: () => void;
   onShareOrCopy: () => void;
 }) {
+  const t = useRuntimeTranslator();
   const nativeMobileShareSupported = isNativeMobileShareSurface();
   const imageCount = attachment.assets.filter(
     (asset) => asset.kind === "image",
@@ -6285,18 +6288,18 @@ function NoteViewerOverlay({
         type="button"
         onClick={onClose}
         className="absolute inset-0 cursor-default"
-        aria-label="关闭笔记预览"
+        aria-label={t(msg`关闭笔记预览`)}
       />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(7,193,96,0.18),transparent_34%),linear-gradient(180deg,rgba(15,23,42,0.12),rgba(15,23,42,0.74))]" />
       <div className="relative flex h-full flex-col">
         <div className="flex items-center justify-between px-4 pb-3 pt-[max(env(safe-area-inset-top,0px),1rem)] text-white">
           <div>
             <div className="text-[12px] uppercase tracking-[0.18em] text-white/60">
-              聊天笔记
+              {t(msg`聊天笔记`)}
             </div>
-            <div className="mt-1 text-[18px] font-medium">笔记摘要</div>
+            <div className="mt-1 text-[18px] font-medium">{t(msg`笔记摘要`)}</div>
           </div>
-          <ViewerActionButton compact label="关闭笔记预览" onClick={onClose}>
+          <ViewerActionButton compact label={t(msg`关闭笔记预览`)} onClick={onClose}>
             <X size={18} />
           </ViewerActionButton>
         </div>
@@ -6315,7 +6318,7 @@ function NoteViewerOverlay({
             ) : (
               <div className="flex h-40 items-end border-b border-white/10 bg-[linear-gradient(160deg,rgba(243,246,245,0.2),rgba(221,230,227,0.1))] px-5 py-5">
                 <div className="rounded-[16px] border border-white/12 bg-white/10 px-4 py-2 text-[12px] tracking-[0.18em] text-white/72">
-                  收藏笔记
+                  {t(msg`收藏笔记`)}
                 </div>
               </div>
             )}
@@ -6325,11 +6328,11 @@ function NoteViewerOverlay({
                 {attachment.title}
               </div>
               <div className="mt-2 text-[12px] text-white/62">
-                最近更新于 {updatedAtLabel}
+                {t(msg`最近更新于 ${updatedAtLabel}`)}
               </div>
 
               <div className="mt-4 rounded-[20px] border border-white/10 bg-white/6 px-4 py-4 text-[14px] leading-7 text-white/82">
-                {attachment.excerpt?.trim() || "这条笔记暂时没有可展示的摘要内容。"}
+                {attachment.excerpt?.trim() || t(msg`这条笔记暂时没有可展示的摘要内容。`)}
               </div>
 
               {attachment.tags.length ? (
@@ -6347,21 +6350,21 @@ function NoteViewerOverlay({
 
               <div className="mt-5 grid grid-cols-3 gap-2.5">
                 <NoteViewerMetric
-                  label="图片"
-                  value={imageCount > 0 ? `${imageCount} 张` : "无"}
+                  label={t(msg`图片`)}
+                  value={imageCount > 0 ? t(msg`${imageCount} 张`) : t(msg`无`)}
                 />
                 <NoteViewerMetric
-                  label="文件"
-                  value={fileCount > 0 ? `${fileCount} 个` : "无"}
+                  label={t(msg`文件`)}
+                  value={fileCount > 0 ? t(msg`${fileCount} 个`) : t(msg`无`)}
                 />
                 <NoteViewerMetric
-                  label="内容"
-                  value={attachment.excerpt?.trim() ? "有摘要" : "待补充"}
+                  label={t(msg`内容`)}
+                  value={attachment.excerpt?.trim() ? t(msg`有摘要`) : t(msg`待补充`)}
                 />
               </div>
 
               <div className="mt-5 rounded-[18px] border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.06)] px-4 py-3 text-[12px] leading-6 text-white/70">
-                手机端当前提供笔记摘要预览；完整编辑与详情工作区仍需在桌面布局中打开。
+                {t(msg`手机端当前提供笔记摘要预览；完整编辑与详情工作区仍需在桌面布局中打开。`)}
               </div>
             </div>
           </div>
@@ -6369,7 +6372,7 @@ function NoteViewerOverlay({
 
         <div className="flex flex-wrap items-center justify-center gap-3 px-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)] pt-2">
           <ViewerActionButton
-            label={nativeMobileShareSupported ? "系统分享" : "复制摘要"}
+            label={nativeMobileShareSupported ? t(msg`系统分享`) : t(msg`复制摘要`)}
             onClick={onShareOrCopy}
           >
             {nativeMobileShareSupported ? (
@@ -6378,7 +6381,7 @@ function NoteViewerOverlay({
               <Copy size={16} />
             )}
           </ViewerActionButton>
-          <ViewerActionButton label="定位消息" onClick={onLocate}>
+          <ViewerActionButton label={t(msg`定位消息`)} onClick={onLocate}>
             <FileText size={16} />
           </ViewerActionButton>
         </div>

--- a/apps/app/src/features/chat/stickers/sticker-panel.tsx
+++ b/apps/app/src/features/chat/stickers/sticker-panel.tsx
@@ -1838,7 +1838,7 @@ export function StickerPanel({
       className={
         isMobile
           ? "mt-1.5 overflow-hidden rounded-[18px] border border-[color:var(--border-subtle)] bg-[color:var(--surface-panel)]"
-          : "absolute bottom-full left-0 z-40 mb-3 w-[430px] overflow-hidden rounded-[24px] border border-[color:var(--border-faint)] bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(250,248,244,0.98))] p-3 shadow-[0_18px_34px_rgba(15,23,42,0.16)]"
+          : "absolute bottom-full left-0 z-50 mb-3 w-[430px] overflow-hidden rounded-[24px] border border-[color:var(--border-faint)] bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(250,248,244,0.98))] p-3 shadow-[0_18px_34px_rgba(15,23,42,0.16)]"
       }
     >
       <div className={isMobile ? "flex h-[284px] flex-col" : undefined}>

--- a/apps/app/src/features/contacts/contact-detail-pane.tsx
+++ b/apps/app/src/features/contacts/contact-detail-pane.tsx
@@ -113,6 +113,7 @@ export function ContactDetailPane({
   const updateProfileMutation = useMutation({
     mutationFn: async (payload: UpdateFriendProfileRequest) => {
       if (!character || !friendship) {
+        // i18n-ignore-next-line: internal mutation guard, never user-visible (component returns earlier)
         throw new Error("Friend not found");
       }
 

--- a/apps/app/src/features/search/desktop-search-launcher.tsx
+++ b/apps/app/src/features/search/desktop-search-launcher.tsx
@@ -1275,7 +1275,7 @@ export function DesktopSearchDropdownPanel({
   return (
     <div
       className={cn(
-        "absolute left-0 right-0 top-[calc(100%+0.45rem)] z-30 overflow-hidden rounded-[16px] border border-[color:var(--border-faint)] bg-white/98 p-2.5 shadow-[var(--shadow-overlay)] backdrop-blur-xl",
+        "absolute left-0 right-0 top-[calc(100%+0.45rem)] z-30 max-h-[calc(100vh-7rem)] overflow-y-auto overscroll-contain rounded-[16px] border border-[color:var(--border-faint)] bg-white/98 p-2.5 shadow-[var(--shadow-overlay)] backdrop-blur-xl",
         className,
       )}
     >

--- a/apps/app/src/features/shell/desktop-shell.tsx
+++ b/apps/app/src/features/shell/desktop-shell.tsx
@@ -412,6 +412,12 @@ export function DesktopShell({ children }: PropsWithChildren) {
     navigateDesktopShellTo("/tabs/moments");
   };
 
+  const openEditSignatureShortcut = () => {
+    setOwnerCardNotice(null);
+    setIsOwnerCardOpen(false);
+    navigateDesktopShellTo("/desktop/settings");
+  };
+
   const openSelfChatShortcut = async () => {
     if (!ownerId || isOpeningSelfChat) {
       return;
@@ -556,6 +562,7 @@ export function DesktopShell({ children }: PropsWithChildren) {
                     onOpenSelfChat={() => {
                       void openSelfChatShortcut();
                     }}
+                    onEditSignature={openEditSignatureShortcut}
                   />
                 ) : null}
               </div>
@@ -910,6 +917,7 @@ function DesktopOwnerQuickCard({
   isOpeningSelfChat,
   onOpenMoments,
   onOpenSelfChat,
+  onEditSignature,
 }: {
   ownerName: string | null;
   ownerAvatar: string;
@@ -918,6 +926,7 @@ function DesktopOwnerQuickCard({
   isOpeningSelfChat: boolean;
   onOpenMoments: () => void;
   onOpenSelfChat: () => void;
+  onEditSignature: () => void;
 }) {
   const t = useRuntimeTranslator();
   const ownerDisplayName = ownerName?.trim() || "";
@@ -935,17 +944,29 @@ function DesktopOwnerQuickCard({
                 {ownerDisplayName}
               </div>
             ) : null}
-            <div
-              className={cn(
-                "line-clamp-2 text-[12px] leading-5",
-                ownerDisplayName ? "mt-1.5" : "",
-                trimmedSignature
-                  ? "text-[color:var(--text-secondary)]"
-                  : "text-[color:var(--text-muted)]",
-              )}
-            >
-              {trimmedSignature || signaturePlaceholder}
-            </div>
+            {trimmedSignature ? (
+              <div
+                className={cn(
+                  "line-clamp-2 text-[12px] leading-5 text-[color:var(--text-secondary)]",
+                  ownerDisplayName ? "mt-1.5" : "",
+                )}
+              >
+                {trimmedSignature}
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={onEditSignature}
+                className={cn(
+                  "block w-full rounded-[8px] border-0 bg-transparent p-0 text-left text-[12px] leading-5 text-[color:var(--text-muted)] appearance-none transition-colors duration-[var(--motion-fast)] ease-[var(--ease-standard)] hover:text-[color:var(--brand-primary)]",
+                  ownerDisplayName ? "mt-1.5" : "",
+                )}
+              >
+                <span className="line-clamp-2 underline decoration-dotted decoration-[color:var(--text-muted)] underline-offset-2 hover:decoration-[color:var(--brand-primary)]">
+                  {signaturePlaceholder}
+                </span>
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/app/src/routes/discover-encounter-page.tsx
+++ b/apps/app/src/routes/discover-encounter-page.tsx
@@ -94,6 +94,7 @@ function MobileDiscoverEncounterPage() {
   });
 
   useEffect(() => {
+    // i18n-ignore-next-line: clears local notice state, not user-visible copy
     setMessage("");
   }, [baseUrl]);
 

--- a/apps/app/src/routes/discover-scene-page.tsx
+++ b/apps/app/src/routes/discover-scene-page.tsx
@@ -135,6 +135,7 @@ function MobileDiscoverScenePage() {
   });
 
   useEffect(() => {
+    // i18n-ignore-next-line: clears local notice state, not user-visible copy
     setMessage("");
   }, [baseUrl]);
 

--- a/apps/app/src/routes/friend-requests-page.tsx
+++ b/apps/app/src/routes/friend-requests-page.tsx
@@ -481,11 +481,9 @@ function formatFriendRequestDate(t: Translator, createdAt: string) {
     return t(msg`今天`);
   }
 
-  const formatter = new Intl.DateTimeFormat("zh-CN", {
-    month: "2-digit",
-    day: "2-digit",
-  });
-  return formatter.format(date).replace(/\//g, "-");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${month}-${day}`;
 }
 
 function MobileFriendRequestsStatusCard({

--- a/apps/app/src/routes/group-chat-background-page.tsx
+++ b/apps/app/src/routes/group-chat-background-page.tsx
@@ -568,7 +568,7 @@ export function GroupChatBackgroundPage() {
                     onClick={() => openPicker("group")}
                     className={!isDesktopLayout ? "min-h-11 rounded-full px-4" : undefined}
                   >
-                    上传图片
+                    {t(msg`上传图片`)}
                   </Button>
                   <Button
                     variant="ghost"

--- a/apps/app/src/routes/moments-page.tsx
+++ b/apps/app/src/routes/moments-page.tsx
@@ -380,6 +380,7 @@ export function MomentsPage() {
 
     setNoticeActionLabel(null);
     setNoticeAction(null);
+    // i18n-ignore-next-line: clears notice state, not user-visible copy
     setNotice("");
   }, [baseUrl, resetComposeDraft]);
 
@@ -436,6 +437,7 @@ export function MomentsPage() {
     }
 
     const timer = window.setTimeout(() => {
+      // i18n-ignore-next-line: clears notice state, not user-visible copy
       setNotice("");
       setNoticeActionLabel(null);
       setNoticeAction(null);

--- a/apps/cloud-console/src/components/root-layout.tsx
+++ b/apps/cloud-console/src/components/root-layout.tsx
@@ -19,6 +19,7 @@ import {
 } from "../lib/cloud-console-i18n";
 import { ConsoleNoticeProvider, useConsoleNotice } from "./console-notice";
 import { ConsoleNoticeToast } from "./ui/console-notice-toast";
+import { NavSection } from "./ui/nav-section";
 
 const NAV_LINK =
   "block rounded-[20px] border border-transparent px-3.5 py-2.5 text-sm text-[color:var(--text-secondary)] transition-[background-color,border-color,color] duration-[var(--motion-fast)] ease-[var(--ease-standard)] hover:border-[color:var(--border-subtle)] hover:bg-[color:var(--surface-card)] hover:text-[color:var(--text-primary)]";
@@ -26,6 +27,42 @@ const NAV_LINK_ACTIVE =
   "block rounded-[20px] border border-[color:var(--border-brand)] bg-[color:var(--surface-card)] px-3.5 py-2.5 text-sm font-semibold text-[color:var(--text-primary)] shadow-[var(--shadow-soft)]";
 const SECRET_INPUT =
   "w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-input)] px-3 py-2 text-sm text-[color:var(--text-primary)] placeholder-[color:var(--text-muted)] outline-none transition focus:border-[color:var(--border-brand)]";
+
+// i18n-ignore-start: section titles re-use the route-meta eyebrows already routed through `t(...)`.
+const NAV_GROUPS = [
+  {
+    key: "cloud",
+    title: "Cloud operations",
+    keys: ["dashboard", "worlds", "sessions"] as const,
+    collapsible: false,
+  },
+  {
+    key: "saas",
+    title: "SaaS operations",
+    keys: [
+      "users",
+      "plans",
+      "configs",
+      "invite-audit",
+      "feedbacks",
+      "telemetry",
+    ] as const,
+    collapsible: false,
+  },
+  {
+    key: "monetization",
+    title: "Cloud monetization",
+    keys: ["revenue-sharing"] as const,
+    collapsible: false,
+  },
+  {
+    key: "tools",
+    title: "Operational tools",
+    keys: ["jobs", "waiting-sync"] as const,
+    collapsible: true,
+  },
+] as const;
+// i18n-ignore-end
 
 type RouteMeta = {
   eyebrow: string;
@@ -512,16 +549,35 @@ function RootLayoutContent() {
           </div>
 
           <nav className="mt-4 flex-1 space-y-5 overflow-y-auto pr-1">
-            <section>
-              <div className="px-1 text-[10px] uppercase tracking-[0.24em] text-[color:var(--text-muted)]">
-                {t("Navigation")}
-              </div>
-              <div className="mt-2 space-y-1">
-                {navItems.map((item) => (
-                  <div key={item.key}>{item.content}</div>
-                ))}
-              </div>
-            </section>
+            {NAV_GROUPS.map((group) => {
+              const groupItems = navItems.filter((item) =>
+                group.keys.includes(item.key),
+              );
+              if (!groupItems.length) {
+                return null;
+              }
+              return (
+                <NavSection
+                  key={group.key}
+                  title={t(group.title)}
+                  collapsible={group.collapsible}
+                  defaultOpen={
+                    group.collapsible
+                      ? groupItems.some(
+                          (item) =>
+                            (item.key === "jobs" && pathname === "/jobs") ||
+                            (item.key === "waiting-sync" &&
+                              pathname === "/waiting-sync"),
+                        )
+                      : true
+                  }
+                >
+                  {groupItems.map((item) => (
+                    <div key={item.key}>{item.content}</div>
+                  ))}
+                </NavSection>
+              );
+            })}
           </nav>
 
           <div className="mt-4 border-t border-[color:var(--border-faint)] pt-4">

--- a/apps/cloud-console/src/lib/cloud-console-i18n.ts
+++ b/apps/cloud-console/src/lib/cloud-console-i18n.ts
@@ -1463,31 +1463,6 @@ export function formatCloudConsoleJobLeaseAvailable(
   });
 }
 
-export function formatCloudConsoleProviderWorldsCount(
-  count: number,
-  locale?: string | null,
-) {
-  return selectCloudConsoleText(locale, {
-    "en-US": `${count} worlds`,
-    "zh-CN": `${count} 个世界`,
-    "ja-JP": `${count} ワールド`,
-    "ko-KR": `${count}개 월드`,
-  });
-}
-
-export function formatCloudConsoleProviderRunningError(
-  running: number,
-  errorCount: number,
-  locale?: string | null,
-) {
-  return selectCloudConsoleText(locale, {
-    "en-US": `Running ${running} · Error ${errorCount}`,
-    "zh-CN": `运行中 ${running} · 错误 ${errorCount}`,
-    "ja-JP": `実行中 ${running} · エラー ${errorCount}`,
-    "ko-KR": `실행 중 ${running} · 오류 ${errorCount}`,
-  });
-}
-
 export function formatCloudConsoleLastGeneratedAt(
   date: string,
   locale?: string | null,

--- a/apps/cloud-console/src/routes/dashboard-page.tsx
+++ b/apps/cloud-console/src/routes/dashboard-page.tsx
@@ -9,7 +9,6 @@ import type {
   WorldLifecycleJobSummary,
 } from "@yinjie/contracts";
 import {
-  compareByLocale,
   formatDateTime as formatLocaleDateTime,
   useAppLocale,
 } from "@yinjie/i18n";
@@ -25,12 +24,9 @@ import { WorldLifecycleActionButtons } from "../components/world-lifecycle-actio
 import { cloudAdminApi } from "../lib/cloud-admin-api";
 import {
   formatCloudConsoleLastGeneratedAt,
-  formatCloudConsoleProviderRunningError,
-  formatCloudConsoleProviderWorldsCount,
   translateCloudConsoleTextForActiveLocale,
   useCloudConsoleText,
 } from "../lib/cloud-console-i18n";
-import { localizeProviderLabel } from "../lib/provider-i18n";
 import { resolveQueueState } from "../lib/job-queue-state";
 import { describeJobResult, getJobAuditBadgeLabel } from "../lib/job-result";
 import { buildCompactJobsRouteSearch } from "../lib/job-route-search";
@@ -54,7 +50,6 @@ import {
 import {
   buildCompactWorldsRouteSearch,
   buildWorldsRouteSearch,
-  UNASSIGNED_PROVIDER_FILTER,
 } from "../lib/world-route-search";
 
 function getMetricTone(value: number) {
@@ -242,83 +237,6 @@ export function DashboardPage() {
     () => buildProviderLabelMap(providersQuery.data),
     [providersQuery.data],
   );
-  const fleetSummary = useMemo(() => {
-    const summary = {
-      running: 0,
-      stopped: 0,
-      error: 0,
-      absent: 0,
-      assignedProviders: new Set<string>(),
-      unassignedWorlds: 0,
-    };
-
-    for (const item of fleetItems) {
-      const powerState = resolvePowerState(item);
-      if (powerState === "running") {
-        summary.running += 1;
-      } else if (powerState === "stopped") {
-        summary.stopped += 1;
-      } else if (powerState === "error") {
-        summary.error += 1;
-      } else if (powerState === "absent") {
-        summary.absent += 1;
-      }
-
-      const providerKey = resolveProviderKey(item);
-      if (providerKey) {
-        summary.assignedProviders.add(providerKey);
-      } else {
-        summary.unassignedWorlds += 1;
-      }
-    }
-
-    return summary;
-  }, [fleetItems]);
-  const providerSummary = useMemo(() => {
-    const summaryByProvider = new Map<
-      string,
-      {
-        key: string;
-        label: string;
-        worlds: number;
-        running: number;
-        error: number;
-      }
-    >();
-
-    for (const item of fleetItems) {
-      const providerKey = resolveProviderKey(item) || "__unassigned__";
-      const label =
-        providerKey === "__unassigned__"
-          ? t("Unassigned")
-          : (providerLabelByKey.get(providerKey) ?? providerKey);
-      const powerState = resolvePowerState(item);
-      const entry = summaryByProvider.get(providerKey) ?? {
-        key: providerKey,
-        label,
-        worlds: 0,
-        running: 0,
-        error: 0,
-      };
-
-      entry.worlds += 1;
-      if (powerState === "running") {
-        entry.running += 1;
-      }
-      if (powerState === "error") {
-        entry.error += 1;
-      }
-
-      summaryByProvider.set(providerKey, entry);
-    }
-
-    return [...summaryByProvider.values()]
-      .sort(
-        (left, right) =>
-          right.worlds - left.worlds || compareByLocale(left.label, right.label),
-      )
-      .slice(0, 4);
-  }, [fleetItems, providerLabelByKey]);
   const fleetMetaByWorldId = useMemo(
     () =>
       new Map(
@@ -517,204 +435,6 @@ export function DashboardPage() {
             ))}
           </div>
         ) : null}
-
-        <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <WorldsPermalinkLink
-            search={buildCompactWorldsRouteSearch({ status: "ready" })}
-            aria-label={t("Filter worlds by ready status")}
-            className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4 transition hover:border-[color:var(--border-strong)]"
-          >
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Ready worlds")}
-            </div>
-            <div
-              className={`mt-3 text-3xl font-semibold ${getMetricTone(
-                driftSummary?.readyWorlds ?? 0,
-              )}`}
-            >
-              {driftSummary?.readyWorlds ?? 0}
-            </div>
-            <div className="mt-2 text-sm text-[color:var(--text-secondary)]">
-              Total fleet: {driftSummary?.totalWorlds ?? 0}
-            </div>
-          </WorldsPermalinkLink>
-
-          <WorldsPermalinkLink
-            search={buildCompactWorldsRouteSearch({ attention: "critical" })}
-            aria-label={t("Filter worlds by critical attention")}
-            className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4 transition hover:border-[color:var(--border-strong)]"
-          >
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Critical attention")}
-            </div>
-            <div
-              className={`mt-3 text-3xl font-semibold ${getMetricTone(
-                driftSummary?.criticalAttentionWorlds ?? 0,
-              )}`}
-            >
-              {driftSummary?.criticalAttentionWorlds ?? 0}
-            </div>
-            <div className="mt-2 text-sm text-[color:var(--text-secondary)]">
-              Warning: {driftSummary?.warningAttentionWorlds ?? 0}
-            </div>
-          </WorldsPermalinkLink>
-
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Recovery queued")}
-            </div>
-            <div
-              className={`mt-3 text-3xl font-semibold ${getMetricTone(
-                driftSummary?.recoveryQueuedWorlds ?? 0,
-              )}`}
-            >
-              {driftSummary?.recoveryQueuedWorlds ?? 0}
-            </div>
-            <div className="mt-2 text-sm text-[color:var(--text-secondary)]">
-              Heartbeat stale: {driftSummary?.heartbeatStaleWorlds ?? 0}
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Provider drift")}
-            </div>
-            <div
-              className={`mt-3 text-3xl font-semibold ${getMetricTone(
-                driftSummary?.providerDriftWorlds ?? 0,
-              )}`}
-            >
-              {driftSummary?.providerDriftWorlds ?? 0}
-            </div>
-            <div className="mt-2 text-sm text-[color:var(--text-secondary)]">
-              Failed: {driftSummary?.failedWorlds ?? 0}
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-5 grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="flex items-center justify-between gap-3">
-              <div className="text-sm font-semibold text-[color:var(--text-primary)]">
-                {t("Instance pool")}
-              </div>
-              <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-                {fleetItems.length} worlds
-              </div>
-            </div>
-
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-              <WorldsPermalinkLink
-                search={buildCompactWorldsRouteSearch({ powerState: "running" })}
-                aria-label={t("Filter worlds by running instances")}
-                className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-3 transition hover:border-[color:var(--border-strong)]"
-              >
-                <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-                  {t("Running")}
-                </div>
-                <div className={`mt-2 text-2xl font-semibold ${getMetricTone(fleetSummary.running)}`}>
-                  {fleetSummary.running}
-                </div>
-              </WorldsPermalinkLink>
-              <WorldsPermalinkLink
-                search={buildCompactWorldsRouteSearch({ powerState: "stopped" })}
-                aria-label={t("Filter worlds by stopped instances")}
-                className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-3 transition hover:border-[color:var(--border-strong)]"
-              >
-                <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-                  {t("Stopped")}
-                </div>
-                <div className={`mt-2 text-2xl font-semibold ${getMetricTone(fleetSummary.stopped)}`}>
-                  {fleetSummary.stopped}
-                </div>
-              </WorldsPermalinkLink>
-              <WorldsPermalinkLink
-                search={buildCompactWorldsRouteSearch({ powerState: "error" })}
-                aria-label={t("Filter worlds by error instances")}
-                className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-3 transition hover:border-[color:var(--border-strong)]"
-              >
-                <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-                  {t("Error")}
-                </div>
-                <div className={`mt-2 text-2xl font-semibold ${getMetricTone(fleetSummary.error)}`}>
-                  {fleetSummary.error}
-                </div>
-              </WorldsPermalinkLink>
-              <WorldsPermalinkLink
-                search={buildCompactWorldsRouteSearch({
-                  provider: UNASSIGNED_PROVIDER_FILTER,
-                })}
-                aria-label={t("Filter worlds by unassigned provider")}
-                className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-3 transition hover:border-[color:var(--border-strong)]"
-              >
-                <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-                  {t("Unassigned")}
-                </div>
-                <div
-                  className={`mt-2 text-2xl font-semibold ${getMetricTone(fleetSummary.unassignedWorlds)}`}
-                >
-                  {fleetSummary.unassignedWorlds}
-                </div>
-              </WorldsPermalinkLink>
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="flex items-center justify-between gap-3">
-              <div className="text-sm font-semibold text-[color:var(--text-primary)]">
-                {t("Provider spread")}
-              </div>
-              <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-                {fleetSummary.assignedProviders.size} active providers
-              </div>
-            </div>
-
-            <div className="mt-4 space-y-3">
-              {providerSummary.map((provider) => {
-                const localizedProviderLabel = localizeProviderLabel(
-                  provider.key,
-                  provider.label,
-                  locale,
-                );
-                return (
-                  <WorldsPermalinkLink
-                    key={provider.key}
-                    search={buildCompactWorldsRouteSearch({
-                      provider: provider.key,
-                    })}
-                    aria-label={`${t("Filter worlds by provider")} ${localizedProviderLabel}`}
-                    className="block rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-3 transition hover:border-[color:var(--border-strong)]"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="text-sm text-[color:var(--text-primary)]">
-                        {localizedProviderLabel}
-                      </div>
-                      <div className="text-xs text-[color:var(--text-muted)]">
-                        {formatCloudConsoleProviderWorldsCount(
-                          provider.worlds,
-                          locale,
-                        )}
-                      </div>
-                    </div>
-                    <div className="mt-2 text-xs text-[color:var(--text-secondary)]">
-                      {formatCloudConsoleProviderRunningError(
-                        provider.running,
-                        provider.error,
-                        locale,
-                      )}
-                    </div>
-                  </WorldsPermalinkLink>
-                );
-              })}
-
-              {!instanceFleetQuery.isLoading && providerSummary.length === 0 ? (
-                <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-3 text-sm text-[color:var(--text-muted)]">
-                  {t("No provider allocation data yet.")}
-                </div>
-              ) : null}
-            </div>
-          </div>
-        </div>
 
         <div className="mt-4 text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
           {formatCloudConsoleLastGeneratedAt(

--- a/apps/cloud-console/src/routes/dashboard-page.tsx
+++ b/apps/cloud-console/src/routes/dashboard-page.tsx
@@ -38,6 +38,7 @@ import {
   createRequestScopedNotice,
   showRequestScopedNotice,
 } from "../lib/request-scoped-notice";
+import { PageHeader, SurfaceCard } from "../components/ui";
 import {
   DASHBOARD_ACTIVE_JOB_ACTIONS,
   DASHBOARD_ATTENTION_ACTIONS,
@@ -487,33 +488,27 @@ export function DashboardPage() {
 
   return (
     <section className="space-y-6">
-      <div className="rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <div className="text-xl font-semibold text-[color:var(--text-primary)]">
-              {t("Fleet Dashboard")}
-            </div>
-            <div className="mt-1 max-w-3xl text-sm text-[color:var(--text-secondary)]">
-              Quick view of world availability, queued recovery, and the most
-              urgent runtime drift signals across the cloud fleet.
-            </div>
-          </div>
-
-          <div className="flex flex-wrap gap-3 text-sm">
-            <WorldsPermalinkLink
-              search={buildCompactWorldsRouteSearch()}
-              className="rounded-full border border-[color:var(--border-faint)] px-4 py-2 text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-primary)]"
-            >
-              {t("Open worlds")}
-            </WorldsPermalinkLink>
-            <JobsPermalinkLink
-              search={buildCompactJobsRouteSearch()}
-              className="rounded-full border border-[color:var(--border-faint)] px-4 py-2 text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-primary)]"
-            >
-              {t("Inspect jobs")}
-            </JobsPermalinkLink>
-          </div>
-        </div>
+      <SurfaceCard>
+        <PageHeader
+          title={t("Fleet Dashboard")}
+          subtitle="Quick view of world availability, queued recovery, and the most urgent runtime drift signals across the cloud fleet."
+          actions={
+            <>
+              <WorldsPermalinkLink
+                search={buildCompactWorldsRouteSearch()}
+                className="rounded-full border border-[color:var(--border-faint)] px-4 py-2 text-sm text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-primary)]"
+              >
+                {t("Open worlds")}
+              </WorldsPermalinkLink>
+              <JobsPermalinkLink
+                search={buildCompactJobsRouteSearch()}
+                className="rounded-full border border-[color:var(--border-faint)] px-4 py-2 text-sm text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-primary)]"
+              >
+                {t("Inspect jobs")}
+              </JobsPermalinkLink>
+            </>
+          }
+        />
 
         {pageErrors.length ? (
           <div className="mt-4 space-y-3">
@@ -727,7 +722,7 @@ export function DashboardPage() {
             locale,
           )}
         </div>
-      </div>
+      </SurfaceCard>
 
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <div className="rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">

--- a/apps/cloud-console/src/routes/jobs-page.tsx
+++ b/apps/cloud-console/src/routes/jobs-page.tsx
@@ -72,7 +72,13 @@ import {
   performWorldLifecycleActionWithMeta,
   type WorldLifecycleAction,
 } from "../lib/world-lifecycle-actions";
-import { SurfaceCard } from "../components/ui";
+import {
+  FilterAdvanced,
+  FilterBar,
+  FilterSearch,
+  FilterSelect,
+  SurfaceCard,
+} from "../components/ui";
 
 const UNASSIGNED_PROVIDER_FILTER = "__unassigned__";
 
@@ -472,25 +478,16 @@ export function JobsPage() {
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            onClick={() => void copyJobsPermalink()}
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)] hover:bg-[color:var(--surface-soft)]"
-          >
-            {t("Copy jobs permalink")}
-          </button>
-
-          <input
+        <FilterBar>
+          <FilterSearch
             value={query}
             onChange={(event) =>
               updateFilters({ query: event.target.value, page: 1 })
             }
             placeholder={t("Search world, phone, job, lease...")}
-            className="min-w-[16rem] rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)] placeholder:text-[color:var(--text-muted)]"
           />
 
-          <select
+          <FilterSelect
             value={status}
             onChange={(event) =>
               updateFilters({
@@ -498,16 +495,15 @@ export function JobsPage() {
                 page: 1,
               })
             }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
           >
             {JOB_STATUS_FILTERS.map((item) => (
               <option key={item} value={item}>
                 status: {item}
               </option>
             ))}
-          </select>
+          </FilterSelect>
 
-          <select
+          <FilterSelect
             value={jobType}
             onChange={(event) =>
               updateFilters({
@@ -515,31 +511,15 @@ export function JobsPage() {
                 page: 1,
               })
             }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
           >
             {JOB_TYPE_FILTERS.map((item) => (
               <option key={item} value={item}>
                 type: {item}
               </option>
-              ))}
-          </select>
-
-          <select
-            value={providerFilter}
-            onChange={(event) =>
-              updateFilters({ provider: event.target.value, page: 1 })
-            }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
-          >
-            <option value="all">provider: all</option>
-            {providerOptions.map((provider) => (
-              <option key={provider.key} value={provider.key}>
-                provider: {provider.label}
-              </option>
             ))}
-          </select>
+          </FilterSelect>
 
-          <select
+          <FilterSelect
             value={queueStateFilter}
             onChange={(event) =>
               updateFilters({
@@ -547,100 +527,118 @@ export function JobsPage() {
                 page: 1,
               })
             }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
+          >
+            {getQueueStateFilters().map((item) => (
+              <option key={item.value} value={item.value}>
+                {item.label}
+              </option>
+            ))}
+          </FilterSelect>
+
+          <FilterAdvanced summary={t("More filters")}>
+            <button
+              type="button"
+              onClick={() => void copyJobsPermalink()}
+              className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)] hover:bg-[color:var(--surface-soft)]"
             >
-              {getQueueStateFilters().map((item) => (
-                <option key={item.value} value={item.value}>
-                  {item.label}
+              {t("Copy jobs permalink")}
+            </button>
+
+            <FilterSelect
+              value={providerFilter}
+              onChange={(event) =>
+                updateFilters({ provider: event.target.value, page: 1 })
+              }
+            >
+              <option value="all">provider: all</option>
+              {providerOptions.map((provider) => (
+                <option key={provider.key} value={provider.key}>
+                  provider: {provider.label}
                 </option>
               ))}
-          </select>
+            </FilterSelect>
 
-          <select
-            value={auditFilter}
-            onChange={(event) =>
-              updateFilters({
-                audit: event.target.value as JobAuditFilter,
-                page: 1,
-              })
-            }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
-          >
-            {JOB_AUDIT_FILTERS.map((item) => (
-              <option key={item} value={item}>
-                audit: {item}
-              </option>
-            ))}
-          </select>
+            <FilterSelect
+              value={auditFilter}
+              onChange={(event) =>
+                updateFilters({
+                  audit: event.target.value as JobAuditFilter,
+                  page: 1,
+                })
+              }
+            >
+              {JOB_AUDIT_FILTERS.map((item) => (
+                <option key={item} value={item}>
+                  audit: {item}
+                </option>
+              ))}
+            </FilterSelect>
 
-          <select
-            value={supersededByFilter}
-            onChange={(event) =>
-              updateFilters({
-                supersededBy: event.target.value as JobSupersededByFilter,
-                page: 1,
-              })
-            }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
-          >
-            {JOB_SUPERSEDED_BY_FILTERS.map((item) => (
-              <option key={item} value={item}>
-                superseded by: {item}
-              </option>
-            ))}
-          </select>
+            <FilterSelect
+              value={supersededByFilter}
+              onChange={(event) =>
+                updateFilters({
+                  supersededBy: event.target.value as JobSupersededByFilter,
+                  page: 1,
+                })
+              }
+            >
+              {JOB_SUPERSEDED_BY_FILTERS.map((item) => (
+                <option key={item} value={item}>
+                  superseded by: {item}
+                </option>
+              ))}
+            </FilterSelect>
 
-          <select
-            value={sortBy}
-            onChange={(event) =>
-              updateFilters({
-                sortBy: event.target.value as JobSortFieldFilter,
-                page: 1,
-              })
-            }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
-          >
-            {JOB_SORT_FIELDS.map((item) => (
-              <option key={item} value={item}>
-                sort by: {item}
-              </option>
-            ))}
-          </select>
+            <FilterSelect
+              value={sortBy}
+              onChange={(event) =>
+                updateFilters({
+                  sortBy: event.target.value as JobSortFieldFilter,
+                  page: 1,
+                })
+              }
+            >
+              {JOB_SORT_FIELDS.map((item) => (
+                <option key={item} value={item}>
+                  sort by: {item}
+                </option>
+              ))}
+            </FilterSelect>
 
-          <select
-            value={sortDirection}
-            onChange={(event) =>
-              updateFilters({
-                sortDirection: event.target.value as JobSortDirectionFilter,
-                page: 1,
-              })
-            }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
-          >
-            {JOB_SORT_DIRECTIONS.map((item) => (
-              <option key={item} value={item}>
-                direction: {item}
-              </option>
-            ))}
-          </select>
+            <FilterSelect
+              value={sortDirection}
+              onChange={(event) =>
+                updateFilters({
+                  sortDirection: event.target.value as JobSortDirectionFilter,
+                  page: 1,
+                })
+              }
+            >
+              {JOB_SORT_DIRECTIONS.map((item) => (
+                <option key={item} value={item}>
+                  direction: {item}
+                </option>
+              ))}
+            </FilterSelect>
 
-          <select
-            value={String(pageSize)}
-            onChange={(event) =>
-              updateFilters({
-                page: 1,
-                pageSize: Number(event.target.value),
-              })
-            }
-            className="rounded-xl border border-[color:var(--border-faint)] bg-[color:var(--surface-input)] px-4 py-2 text-sm text-[color:var(--text-primary)]"
-          >
-            {JOB_PAGE_SIZE_OPTIONS.map((item) => (
-              <option key={item} value={item}>
-                {formatCloudConsolePageSize(item, locale)}
-              </option>
-            ))}
-          </select>
-        </div>
+            <FilterSelect
+              value={String(pageSize)}
+              onChange={(event) =>
+                updateFilters({
+                  page: 1,
+                  pageSize: Number(event.target.value),
+                })
+              }
+            >
+              {JOB_PAGE_SIZE_OPTIONS.map((item) => (
+                <option key={item} value={item}>
+                  {formatCloudConsolePageSize(item, locale)}
+                </option>
+              ))}
+            </FilterSelect>
+          </FilterAdvanced>
+        </FilterBar>
       </div>
 
       {worldId ? (

--- a/apps/cloud-console/src/routes/jobs-page.tsx
+++ b/apps/cloud-console/src/routes/jobs-page.tsx
@@ -72,6 +72,7 @@ import {
   performWorldLifecycleActionWithMeta,
   type WorldLifecycleAction,
 } from "../lib/world-lifecycle-actions";
+import { SurfaceCard } from "../components/ui";
 
 const UNASSIGNED_PROVIDER_FILTER = "__unassigned__";
 
@@ -454,7 +455,7 @@ export function JobsPage() {
   ].filter((error): error is Error => error instanceof Error);
 
   return (
-    <section className="rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">
+    <SurfaceCard>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <div className="text-xl font-semibold text-[color:var(--text-primary)]">
@@ -933,6 +934,6 @@ export function JobsPage() {
           });
         }}
       />
-    </section>
+    </SurfaceCard>
   );
 }

--- a/apps/cloud-console/src/routes/users-page.tsx
+++ b/apps/cloud-console/src/routes/users-page.tsx
@@ -9,6 +9,7 @@ import {
   formatCloudConsolePageOfTotal,
   useCloudConsoleText,
 } from "../lib/cloud-console-i18n";
+import { SurfaceCard } from "../components/ui";
 
 function formatExpiresAt(value?: string | null) {
   if (!value) return "-";
@@ -16,6 +17,9 @@ function formatExpiresAt(value?: string | null) {
   if (Number.isNaN(date.getTime())) return value;
   return formatDateTime(date, { dateStyle: "medium", timeStyle: "short" });
 }
+
+const FILTER_CONTROL_CLASS =
+  "rounded-2xl border border-[color:var(--border-subtle)] bg-white px-3 py-2 text-sm";
 
 export function UsersPage() {
   const t = useCloudConsoleText();
@@ -39,7 +43,7 @@ export function UsersPage() {
   });
 
   return (
-    <section className="space-y-4 rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">
+    <SurfaceCard className="space-y-4">
       <div className="grid gap-3 md:grid-cols-4">
         <input
           value={query}
@@ -48,7 +52,7 @@ export function UsersPage() {
             setPage(1);
           }}
           placeholder={t("Search phone")}
-          className="rounded-2xl border border-[color:var(--border-subtle)] bg-white px-3 py-2 text-sm"
+          className={FILTER_CONTROL_CLASS}
         />
         <select
           value={status}
@@ -56,7 +60,7 @@ export function UsersPage() {
             setStatus(event.target.value as CloudUserStatus | "");
             setPage(1);
           }}
-          className="rounded-2xl border border-[color:var(--border-subtle)] bg-white px-3 py-2 text-sm"
+          className={FILTER_CONTROL_CLASS}
         >
           <option value="">{t("All account states")}</option>
           <option value="active">{t("active")}</option>
@@ -69,7 +73,7 @@ export function UsersPage() {
             setSubscriptionStatus(event.target.value as SubscriptionStatus | "");
             setPage(1);
           }}
-          className="rounded-2xl border border-[color:var(--border-subtle)] bg-white px-3 py-2 text-sm"
+          className={FILTER_CONTROL_CLASS}
         >
           <option value="">{t("All subscription states")}</option>
           <option value="active">{t("active")}</option>
@@ -165,6 +169,6 @@ export function UsersPage() {
           {t("Next")}
         </button>
       </div>
-    </section>
+    </SurfaceCard>
   );
 }

--- a/apps/cloud-console/src/routes/worlds-page.tsx
+++ b/apps/cloud-console/src/routes/worlds-page.tsx
@@ -22,6 +22,12 @@ import { cloudAdminApi } from "../lib/cloud-admin-api";
 import { translateCloudConsoleTextForActiveLocale,
   useCloudConsoleText } from "../lib/cloud-console-i18n";
 import {
+  MetricCard,
+  MetricCardGrid,
+  PageHeader,
+  SurfaceCard,
+} from "../components/ui";
+import {
   createRequestScopedNotice,
   showRequestScopedNotice,
 } from "../lib/request-scoped-notice";
@@ -495,110 +501,68 @@ export function WorldsPage() {
 
   return (
     <div className="space-y-5">
-      <section className="rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <div className="text-xl font-semibold text-[color:var(--text-primary)]">
-              {t("World drift summary")}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              This panel folds together runtime heartbeat freshness,
-              provider-observed drift, and queued recovery jobs.
-            </div>
-          </div>
+      <SurfaceCard>
+        <PageHeader
+          title={t("World drift summary")}
+          subtitle="This panel folds together runtime heartbeat freshness, provider-observed drift, and queued recovery jobs."
+          meta={`Updated ${formatDateTime(driftSummaryQuery.data?.generatedAt)}`}
+        />
 
-          <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-            Updated {formatDateTime(driftSummaryQuery.data?.generatedAt)}
-          </div>
-        </div>
+        <MetricCardGrid cols={4}>
+          <MetricCard
+            label={t("Attention worlds")}
+            value={driftSummaryQuery.data?.attentionWorlds ?? 0}
+            description={t("Worlds that currently need operator attention.")}
+            valueClassName={getMetricTone(
+              driftSummaryQuery.data?.attentionWorlds ?? 0,
+            )}
+          />
+          <MetricCard
+            label={t("Critical alerts")}
+            value={driftSummaryQuery.data?.criticalAttentionWorlds ?? 0}
+            description="Worlds already in critical state, including failed and escalated alerts."
+            valueClassName={getMetricTone(
+              driftSummaryQuery.data?.criticalAttentionWorlds ?? 0,
+            )}
+          />
+          <MetricCard
+            label={t("Escalated worlds")}
+            value={driftSummaryQuery.data?.escalatedWorlds ?? 0}
+            description="Alerts upgraded because retry or stale-heartbeat thresholds were crossed."
+            valueClassName={getMetricTone(
+              driftSummaryQuery.data?.escalatedWorlds ?? 0,
+            )}
+          />
+          <MetricCard
+            label={t("Recovery queued")}
+            value={driftSummaryQuery.data?.recoveryQueuedWorlds ?? 0}
+            description="Worlds that already have active `resume` or `provision` work in flight."
+            valueClassName={getMetricTone(
+              driftSummaryQuery.data?.recoveryQueuedWorlds ?? 0,
+            )}
+          />
+        </MetricCardGrid>
 
-        <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Attention worlds")}
-            </div>
-            <div
-              className={`mt-2 text-3xl font-semibold ${getMetricTone(driftSummaryQuery.data?.attentionWorlds ?? 0)}`}
-            >
-              {driftSummaryQuery.data?.attentionWorlds ?? 0}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              {t("Worlds that currently need operator attention.")}
-            </div>
-          </div>
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Critical alerts")}
-            </div>
-            <div
-              className={`mt-2 text-3xl font-semibold ${getMetricTone(driftSummaryQuery.data?.criticalAttentionWorlds ?? 0)}`}
-            >
-              {driftSummaryQuery.data?.criticalAttentionWorlds ?? 0}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              Worlds already in critical state, including failed and escalated
-              alerts.
-            </div>
-          </div>
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Escalated worlds")}
-            </div>
-            <div
-              className={`mt-2 text-3xl font-semibold ${getMetricTone(driftSummaryQuery.data?.escalatedWorlds ?? 0)}`}
-            >
-              {driftSummaryQuery.data?.escalatedWorlds ?? 0}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              Alerts upgraded because retry or stale-heartbeat thresholds were
-              crossed.
-            </div>
-          </div>
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Recovery queued")}
-            </div>
-            <div
-              className={`mt-2 text-3xl font-semibold ${getMetricTone(driftSummaryQuery.data?.recoveryQueuedWorlds ?? 0)}`}
-            >
-              {driftSummaryQuery.data?.recoveryQueuedWorlds ?? 0}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              Worlds that already have active `resume` or `provision` work in
-              flight.
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-3 grid gap-3 md:grid-cols-2">
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Heartbeat stale")}
-            </div>
-            <div
-              className={`mt-2 text-3xl font-semibold ${getMetricTone(driftSummaryQuery.data?.heartbeatStaleWorlds ?? 0)}`}
-            >
-              {driftSummaryQuery.data?.heartbeatStaleWorlds ?? 0}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              {t("Runtime is not checking in within the configured stale window.")}
-            </div>
-          </div>
-          <div className="rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
-            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-              {t("Provider drift")}
-            </div>
-            <div
-              className={`mt-2 text-3xl font-semibold ${getMetricTone(driftSummaryQuery.data?.providerDriftWorlds ?? 0)}`}
-            >
-              {driftSummaryQuery.data?.providerDriftWorlds ?? 0}
-            </div>
-            <div className="mt-1 text-sm text-[color:var(--text-secondary)]">
-              Provider reports power state that disagrees with desired world
-              state.
-            </div>
-          </div>
-        </div>
+        <MetricCardGrid cols={2} className="mt-3" compact>
+          <MetricCard
+            label={t("Heartbeat stale")}
+            value={driftSummaryQuery.data?.heartbeatStaleWorlds ?? 0}
+            description={t(
+              "Runtime is not checking in within the configured stale window.",
+            )}
+            valueClassName={getMetricTone(
+              driftSummaryQuery.data?.heartbeatStaleWorlds ?? 0,
+            )}
+          />
+          <MetricCard
+            label={t("Provider drift")}
+            value={driftSummaryQuery.data?.providerDriftWorlds ?? 0}
+            description="Provider reports power state that disagrees with desired world state."
+            valueClassName={getMetricTone(
+              driftSummaryQuery.data?.providerDriftWorlds ?? 0,
+            )}
+          />
+        </MetricCardGrid>
 
         <div className="mt-5 rounded-2xl border border-[color:var(--border-faint)] bg-[color:var(--surface-soft)] p-4">
           <div className="text-sm font-medium text-[color:var(--text-primary)]">
@@ -671,9 +635,9 @@ export function WorldsPage() {
             ) : null}
           </div>
         </div>
-      </section>
+      </SurfaceCard>
 
-      <section className="rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">
+      <SurfaceCard>
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="text-xl font-semibold text-[color:var(--text-primary)]">
@@ -835,9 +799,9 @@ export function WorldsPage() {
             </div>
           ) : null}
         </div>
-      </section>
+      </SurfaceCard>
 
-      <section className="rounded-[28px] border border-[color:var(--border-faint)] bg-[color:var(--surface-console)] p-5 shadow-[var(--shadow-section)]">
+      <SurfaceCard>
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <div className="text-xl font-semibold text-[color:var(--text-primary)]">
@@ -1124,7 +1088,7 @@ export function WorldsPage() {
             </div>
           ) : null}
         </div>
-      </section>
+      </SurfaceCard>
 
       <ConsoleConfirmDialog
         open={Boolean(activeConfirm && confirmAction)}

--- a/apps/cloud-console/tests/interactions.test.tsx
+++ b/apps/cloud-console/tests/interactions.test.tsx
@@ -4110,21 +4110,6 @@ describe("cloud-console interactions", () => {
     expect(screen.queryByText("Dashboard retry failed.")).toBeNull();
   });
 
-  it("opens worlds views from dashboard fleet cards", async () => {
-    renderRoute("/");
-
-    expect(await screen.findByText("Instance pool")).toBeTruthy();
-
-    fireEvent.click(
-      await screen.findByRole("link", {
-        name: "Filter worlds by running instances",
-      }),
-    );
-
-    expect(await screen.findByText("Managed worlds")).toBeTruthy();
-    expect(screen.getByDisplayValue("power: running")).toBeTruthy();
-  });
-
   it("opens filtered worlds from attention queue shortcuts", async () => {
     renderRoute("/");
 

--- a/apps/cloud-console/tests/router.smoke.test.tsx
+++ b/apps/cloud-console/tests/router.smoke.test.tsx
@@ -21,7 +21,7 @@ describe("cloud-console router smoke", () => {
 
     expect(await screen.findByText("Fleet Dashboard")).toBeTruthy();
     expect(await screen.findByText("Attention Queue")).toBeTruthy();
-    expect(await screen.findByText("Ready worlds")).toBeTruthy();
+    expect(await screen.findByText("Operator Queue")).toBeTruthy();
     expect(
       (await screen.findByRole("link", { name: "Worlds" })).getAttribute(
         "href",
@@ -47,7 +47,7 @@ describe("cloud-console router smoke", () => {
 
     expect(await screen.findByText("舰队仪表盘")).toBeTruthy();
     expect(await screen.findByText("关注队列")).toBeTruthy();
-    expect(await screen.findByText("就绪世界")).toBeTruthy();
+    expect(await screen.findByText("打开世界")).toBeTruthy();
     expect(
       (await screen.findByRole("link", { name: "用户" })).getAttribute("href"),
     ).toBe("/users");


### PR DESCRIPTION
## Summary

PR 5/5 of the cloud-console UX cleanup series. After PR 4 deleted the dashboard \"Provider spread\" section, two i18n formatters became dead code:

- \`formatCloudConsoleProviderWorldsCount(count, locale)\`
- \`formatCloudConsoleProviderRunningError(running, errorCount, locale)\`

Both confirmed 0 callsites via grep. Removing them.

Stacks on PR 1–4 (#43, #44, #45, #46).

## Note on dropped scope

The original plan called for parameterizing 3 groups of formatters into single APIs:

- \`formatVisibleRange(start, end, total, unit)\` ← merge of 3 \`formatCloudConsoleVisible*Range\`
- \`formatLease(state, value)\` ← merge of 4 lease formatters
- \`formatLabeledTime(label, time)\` ← merge of 4 \`*AtLine\` formatters

After auditing the actual translations, I dropped this scope: each locale's wording is structurally different (zh \"暂无会话\" vs \"暂无分组\" isn't a simple unit swap; en lease prefixes \"remaining\"/\"expires\"/\"available\" each translate differently in zh/ja/ko). Parameterizing would force every callsite to pass a 4-row locale dictionary object inline, replacing a clearly-named function with anonymous data. That's a wash at best, regression at worst. The 11 surviving formatters stay as-is.

## Test plan

- [x] \`pnpm --filter @yinjie/cloud-console exec tsc --noEmit\` clean
- [x] \`pnpm --filter @yinjie/cloud-console test\` → 1 failed | 197 passed (identical to baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)