### PR TITLE
fix(app/chat): 桌面表情/收藏弹窗互斥 & 表情贴按钮弹出

### DIFF
--- a/apps/app/src/components/chat-composer.tsx
+++ b/apps/app/src/components/chat-composer.tsx
@@ -1226,6 +1226,7 @@ export function ChatComposer({
       return;
     }
 
+    setStickerPanelOpen(false);
     setDesktopFavoriteRecords(
       mergeDesktopFavoriteRecords(
         favoritesQuery.data ?? [],
@@ -3066,12 +3067,31 @@ export function ChatComposer({
               <div className="flex items-center justify-between gap-3 border-t border-black/6 bg-[#fafafa] px-3.5 py-2.5">
                 <div className="flex min-w-0 flex-1 items-center gap-2">
                   <DesktopToolbarGroup>
-                    <DesktopToolbarButton
-                      label={t(msg`表情`)}
-                      icon={<Smile size={16} />}
-                      active={stickerPanelOpen}
-                      onClick={toggleStickerPanel}
-                    />
+                    <div className="relative">
+                      <DesktopToolbarButton
+                        label={t(msg`表情`)}
+                        icon={<Smile size={16} />}
+                        active={stickerPanelOpen}
+                        onClick={toggleStickerPanel}
+                      />
+                      {stickerPanelOpen && onSendSticker ? (
+                        <StickerPanel
+                          baseUrl={baseUrl}
+                          variant={variant}
+                          activePackId={activeStickerPackId}
+                          recentItems={recentStickers}
+                          onClose={() => setStickerPanelOpen(false)}
+                          onPackChange={setActiveStickerPackId}
+                          onRecentItemsChange={(items) =>
+                            setRecentStickers(items)
+                          }
+                          onError={setAttachmentError}
+                          onSelect={(sticker) =>
+                            void handleSendSticker(sticker)
+                          }
+                        />
+                      ) : null}
+                    </div>
                   </DesktopToolbarGroup>
                   {onSendAttachment ? (
                     <DesktopToolbarGroup>
@@ -3327,18 +3347,13 @@ export function ChatComposer({
             </div>
           )}
 
-          {stickerPanelOpen && onSendSticker ? (
+          {!isDesktop && stickerPanelOpen && onSendSticker ? (
             <StickerPanel
               baseUrl={baseUrl}
               variant={variant}
               activePackId={activeStickerPackId}
               recentItems={recentStickers}
               onClose={() => {
-                if (isDesktop) {
-                  setStickerPanelOpen(false);
-                  return;
-                }
-
                 returnMobileComposerToText({ focusInput: true });
               }}
               onPackChange={setActiveStickerPackId}


### PR DESCRIPTION
## Summary
- 打开收藏面板时关闭表情面板，避免两个弹窗在桌面端相互覆盖
- 桌面端表情面板从输入框最外层挪到表情按钮所在的 relative 容器内，跟收藏面板一样贴着按钮顶部弹出（mobile 场景保留原位置）

## Test plan
- [ ] 桌面端聊天页：点表情按钮，面板贴着按钮顶部弹出
- [ ] 桌面端聊天页：表情面板打开时点收藏，表情自动收起；反之同理
- [ ] 移动端聊天页：表情/收藏面板位置和行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)